### PR TITLE
4-1  から 5-2まで完成

### DIFF
--- a/src/main/java/jp/co/sample/emp_management/repository/AdministratorRepository.java
+++ b/src/main/java/jp/co/sample/emp_management/repository/AdministratorRepository.java
@@ -58,8 +58,8 @@ public class AdministratorRepository {
 	 * @return 管理者情報 存在しない場合はnullを返します
 	 */
 	public Administrator findByMailAddressAndPassward(String mailAddress, String password) {
-		String sql = "select id,name,mail_address,password from administrators where mail_address= '" + mailAddress + "' and password='" + password + "'";
-		SqlParameterSource param = new MapSqlParameterSource();
+		String sql = "select id,name,mail_address,password from administrators where mail_address = :mailAddress and password = :password;";
+		SqlParameterSource param = new MapSqlParameterSource().addValue("mailAddress", mailAddress).addValue("password", password);
 		List<Administrator> administratorList = template.query(sql, param, ADMINISTRATOR_ROW_MAPPER);
 		if (administratorList.size() == 0) {
 			return null;

--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -141,7 +141,7 @@
 							      給料
 							    </th>
 							    <td>
-							      <span th:utext="${employee.salary + '円'}">400000円</span>
+							      <span th:utext="${#numbers.formatInteger(employee.salary, 3, 'COMMA') + '円'}">400000円</span>
 							    </td>
 							  </tr>
 							  <tr>

--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -79,7 +79,7 @@
 							      従業員名
 							    </th>
 							    <td>
-							     <span th:utext="${employee.name}">山田花子</span>
+							     <span th:text="${employee.name}">山田花子</span>
 							    </td>
 							  </tr>
 							  <tr>
@@ -95,7 +95,7 @@
 							      性別
 							    </th>
 							    <td>
-							      <span th:utext="${employee.gender}">女性</span>
+							      <span th:text="${employee.gender}">女性</span>
 							    </td>
 							  </tr>
 							  <tr>
@@ -103,7 +103,7 @@
 							      入社日
 							    </th>
 							    <td>
-							      <span th:utext="${employee.hireDate}">2012/11/29</span>
+							      <span th:text="${employee.hireDate}">2012/11/29</span>
 							    </td>
 							  </tr>
 							  <tr>
@@ -111,7 +111,7 @@
 							      メールアドレス
 							    </th>
 							    <td>
-							      <span th:utext="${employee.mailAddress}">yamada@sample.com</span>
+							      <span th:text="${employee.mailAddress}">yamada@sample.com</span>
 							    </td>
 							  </tr>
 							  <tr>
@@ -119,7 +119,7 @@
 							      郵便番号
 							    </th>
 							    <td>
-							      <span th:utext="${employee.zipCode}">111-1111</span>
+							      <span th:text="${employee.zipCode}">111-1111</span>
 							    </td>
 							  </tr>
 							  <tr>
@@ -127,7 +127,7 @@
 							      住所
 							    </th>
 							    <td>
-							      <span th:utext="${employee.address}">東京都新宿区1-1-1</span>
+							      <span th:text="${employee.address}">東京都新宿区1-1-1</span>
 							    </td>
 							  </tr>
 							  <tr>
@@ -135,7 +135,7 @@
 							      電話番号
 							    </th>
 							    <td>
-							      <span th:utext="${employee.telephone}">090-0000-0000</span>
+							      <span th:text="${employee.telephone}">090-0000-0000</span>
 							    </td>
 							  </tr>
 							  <tr>
@@ -143,7 +143,7 @@
 							      給料
 							    </th>
 							    <td>
-							      <span th:utext="${#numbers.formatInteger(employee.salary, 3, 'COMMA') + '円'}">400000円</span>
+							      <span th:text="${#numbers.formatInteger(employee.salary, 3, 'COMMA') + '円'}">400000円</span>
 							    </td>
 							  </tr>
 							  <tr>
@@ -151,7 +151,7 @@
 							      特性
 							    </th>
 							    <td>
-							      <span th:utext="${employee.characteristics}">明るく素直な性格です。リーダーシップを発揮します。新卒社員研修の時はグループ開発の時にリーダーを買ってでました。積極性も人間性も抜群です。周りに対する不満も聞いたことがありません。</span>
+							      <span th:text="${employee.characteristics}">明るく素直な性格です。リーダーシップを発揮します。新卒社員研修の時はグループ開発の時にリーダーを買ってでました。積極性も人間性も抜群です。周りに対する不満も聞いたことがありません。</span>
 							    </td>
 							  </tr>
 							  <tr>

--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -103,7 +103,7 @@
 							      入社日
 							    </th>
 							    <td>
-							      <span th:text="${employee.hireDate}">2012/11/29</span>
+							      <span th:text="${#dates.format(employee.hireDate, 'YYYY年MM月dd日')}">2012/11/29</span>
 							    </td>
 							  </tr>
 							  <tr>

--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -143,7 +143,7 @@
 							      給料
 							    </th>
 							    <td>
-							      <span th:text="${#numbers.formatInteger(employee.salary, 3, 'COMMA') + '円'}">400000円</span>
+							      <span th:text="${#numbers.formatInteger(employee.salary, 1, 'COMMA') + '円'}">400000円</span>
 							    </td>
 							  </tr>
 							  <tr>

--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -52,7 +52,9 @@
 
 		<!-- パンくずリスト -->
 		<ol class="breadcrumb">
-			<li>従業員リスト</li>
+			<li>
+			<a th:href="@{/employee/showList}">従業員リスト</a>
+			</li>
 			<li class="active">従業員詳細</li>
 		</ol>
 		

--- a/src/main/resources/templates/employee/list.html
+++ b/src/main/resources/templates/employee/list.html
@@ -80,7 +80,7 @@
 								</a>
 							</td>
 							<td>
-								<span th:text="${employee.hireDate}">2016/12/1</span>
+								<span th:text="${#dates.format(employee.hireDate, 'yyyy年MM月dd日')}">2016/12/1</span>
 							</td>
 							<td>
 								<span th:text="${employee.dependentsCount} + '人'">3人</span>


### PR DESCRIPTION
4-1　日付フォーマットを年月日を入れて表示
4-2　給料にカンマを入れて表示
（初級　価格フォーマットは表示を間違えていた為、修正版の4-1から5-2完成を参照お願い致します。）
4-3　パン屑リストにリンクを入れて表示・遷移
5-1　detileのth:utextをth:textに変更
5-2　adoministoratorRepositoryのfindByMailAddressAndPasswardメゾットのSQL文に指定する値が直書きされていた為修正